### PR TITLE
Refactor/config driven weather app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,108 +1,104 @@
-# Weather View Application
+# Weather View
 
 ## Overview
 
-This is a Python-based application designed to provide real-time weather information for any specified city. Utilizing the OpenWeatherMap API, it displays current weather details such as temperature, weather conditions, humidity, UV index, and more. Additionally, the application supports a 3-day weather forecast with UV index calculations using the pysolar library for solar position calculations. This user-friendly application can be tailored for various global locations.
+A Python application that fetches real-time weather data and 3-day forecasts for any city using the [OpenWeatherMap API](https://openweathermap.org/api). Includes estimated UV index calculations based on solar position via the pysolar library.
 
 ## Features
 
-- Fetches and displays current weather data including temperature, weather description, humidity, UV index, etc.
-- Provides a 3-day weather forecast with UV index calculations using solar position algorithms.
-- Easy to use with interactive command line interface for city selection.
-- Real-time data retrieval from OpenWeatherMap API.
-- UV index calculation using pysolar library for accurate solar position calculations.
-- Input validation for city names and API key verification.
-- Proper timezone handling for accurate local times.
+- Current weather: temperature, humidity, wind, pressure, sunrise/sunset, cloudiness, rain/snow
+- 3-day forecast in 3-hour intervals with UV index estimation
+- Config-driven settings — API parameters, UV peak value, display formats, and input rules live in a JSON file
+- Shared UV calculator module to avoid code duplication
+- Proper error handling with specific messages for timeouts, connection failures, and unexpected responses
+- Input validation for city names (configurable allowed characters)
+- Timezone-aware timestamps using the city's local time
+
+## Project Structure
+
+\```
+weather_view/
+├── main.py                          # Entry point
+├── requirements.txt
+├── .env                             # API key (not committed)
+├── config/
+│   └── weather_config.json          # API URLs, UV settings, display formats
+└── src/
+    ├── __init__.py
+    ├── main_program.py              # CLI input loop
+    ├── get_current_weather.py       # Current weather fetcher
+    ├── get_weather_forecast.py      # Forecast fetcher
+    ├── uv_calculator.py             # Shared UV index estimation
+    └── config_loader.py             # Config file loader with caching
+\```
 
 ## Prerequisites
 
-- Python 3.8+ (tested with Python 3.12)
-- pip (latest version recommended)
+- Python 3.10+
+- pip
 
 ## Installation
 
-### Python and pip
+1. Clone the repository:
+\```bash
+git clone <repository-url>
+cd weather_view
+\```
 
-Ensure you have the correct versions of Python and pip installed. Download Python [here](https://www.python.org/downloads/) which includes pip.
+2. Create a virtual environment and activate it:
+\```bash
+python3 -m venv venv
+source venv/bin/activate
+\```
 
-To check your Python version:
+3. Install dependencies:
+\```bash
+pip install -r requirements.txt
+\```
 
-```bash
-python3 --version
-```
-
-To check your pip version:
-
-```bash
-pip3 --version
-```
-
-## Setting up the project:
-
-1. Clone the repository.
-2. Navigate to the project's root directory.
-3. Setup your `.env` file in the root directory. Add your OpenWeatherMap API key in this format:
-   ```plaintext
-   OPENWEATHERMAP_API_KEY=your_openweathermap_api_key
-   ```
-
-**Note**: The application will check if your API key is properly set before starting. If the API key is missing or invalid, you'll receive clear instructions on how to fix it.
+4. Create a `.env` file in the project root with your API key:
+\```
+OPENWEATHERMAP_API_KEY=your_api_key_here
+\```
 
 You can get a free API key from [OpenWeatherMap](https://openweathermap.org/api).
 
-## Installing dependencies
+## Configuration
 
-1. Navigate to the project's root directory.
-2. Run the following command to install all required dependencies:
+### API Key (`.env`)
 
-```bash
-pip3 install -r requirements.txt
-```
+The API key is loaded from a `.env` file via python-dotenv. The app validates the key on startup and provides clear instructions if it's missing or empty.
 
-### Dependencies included:
+### App Settings (`config/weather_config.json`)
 
-- `python-dotenv`: For loading environment variables from .env file
-- `requests`: For making HTTP API requests to OpenWeatherMap
-- `pytz`: For timezone handling and local time calculations
-- `pysolar`: For solar position calculations used in UV index computation
-
-## Running the application
-
-1. Navigate to the project's root directory.
-2. Run the following command to execute the application:
-
-```bash
-python3 main.py
-```
+Controls API endpoints, request timeout, units, UV estimation peak value, display formats, and allowed characters in city name input. All settings have sensible defaults built into the code as a fallback.
 
 ## Usage
 
-After starting the application, you will be prompted for the following inputs:
+\```bash
+python3 main.py
+\```
 
-1. **City Name**: Enter the name of the city for which you want to fetch weather data (or type "exit" to quit).
-2. **Data Choice**: Enter `1` to fetch the current weather or `2` for the 3-day forecast.
-3. **Next Step**: After displaying the data, choose whether to:
-   - Enter `1` for a new city
-   - Enter `2` to reuse the same city for different data
-   - Enter `3` to quit the application
+You will be prompted for:
 
-The application includes input validation to ensure city names contain only valid characters and will prompt you to re-enter if invalid input is provided.
+1. **City name** — e.g. `helsinki`, `london`, `new york`. Type `exit` to quit.
+2. **Data type** — `1` for current weather, `2` for 3-day forecast.
+3. **Next action** — `1` for new city, `2` to reuse same city, `3` to quit.
+
+## UV Index Note
+
+The UV index is estimated using solar altitude angle calculations (via pysolar), not from a dedicated UV API. The estimation uses a configurable peak UV value (default: 8.0) scaled by `sin(solar_altitude)`. This is an approximation — actual UV depends on cloud cover, ozone, and surface conditions. The UV index will show 0.0 during nighttime hours.
 
 ## Troubleshooting
 
-### Common Issues:
-
-1. **"API key not found" error**: Make sure your `.env` file is in the project root directory and contains the correct API key format.
-2. **"API error" messages**: Check that your OpenWeatherMap API key is valid and active.
-3. **UV index shows 0**: This is normal during nighttime hours in the selected city.
-4. **City not found**: Try using the full city name or check the spelling.
-
-## Credits
-
-This project was developed by yumeangelica. For more information on how this work can be used, please refer to the LICENSE.txt file.
-
-Copyright © 2024 - present; yumeangelica
+- **"API key not found"** — make sure `.env` exists in the project root with the correct format.
+- **"API error"** — verify your API key is valid and active at openweathermap.org.
+- **"Request timed out"** — the weather service may be temporarily unavailable. The timeout is configurable in `weather_config.json`.
+- **UV index is always 0** — normal during nighttime in the queried city.
+- **City not found** — try the full city name or check spelling.
 
 ## License
 
-This project is licensed under the Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License. For more information, see the LICENSE file in this repository.
+This project is licensed under the Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License.
+
+Copyright © 2024 – present, [yumeangelica](https://github.com/yumeangelica)

--- a/config/weather_config.json
+++ b/config/weather_config.json
@@ -1,0 +1,28 @@
+{
+  "_config_version": "1.0",
+
+  "api": {
+    "base_url": "https://api.openweathermap.org/data/2.5",
+    "current_endpoint": "/weather",
+    "forecast_endpoint": "/forecast",
+    "timeout": 10,
+    "units": "metric",
+    "forecast_count": 24
+  },
+
+  "uv": {
+    "peak_value": 8.0,
+    "_peak_note": "Estimated max UV index used for solar altitude scaling. Adjust for latitude/season if needed."
+  },
+
+  "display": {
+    "datetime_format": "%Y-%m-%d %H:%M:%S %Z",
+    "temperature_unit": "°C",
+    "wind_unit": "m/s"
+  },
+
+  "input": {
+    "allowed_extra_chars": "-'. ",
+    "_note": "Letters (a-z, A-Z, åäöÅÄÖ) are always allowed. These are the additional characters permitted in city names."
+  }
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-python-dotenv==1.0.1  # To load environment variables from a .env file
-requests==2.32.3       # For making HTTP requests
-pytz==2024.1 # For working with time zones
-pysolar==0.13
+python-dotenv==1.2.2   # Load API key from .env file
+requests==2.32.5       # HTTP requests (CVE-2024-47081 fix)
+pytz==2026.1.post1     # Timezone handling
+pysolar==0.13          # Solar position for UV index estimation

--- a/src/config_loader.py
+++ b/src/config_loader.py
@@ -1,0 +1,46 @@
+"""Config loader for the weather application."""
+
+import json
+import os
+
+_project_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_config_cache = None
+
+
+def load_config() -> dict:
+    """Load weather_config.json with caching.
+
+    Returns:
+        Config dictionary. Falls back to sensible defaults if file is missing.
+    """
+    global _config_cache
+
+    if _config_cache is not None:
+        return _config_cache
+
+    config_path = os.path.join(_project_root, 'config', 'weather_config.json')
+
+    try:
+        with open(config_path, 'r', encoding='utf-8') as f:
+            _config_cache = json.load(f)
+    except (FileNotFoundError, json.JSONDecodeError) as e:
+        print(f"  Warning: Could not load config ({e}). Using defaults.")
+        _config_cache = {
+            "api": {
+                "base_url": "https://api.openweathermap.org/data/2.5",
+                "current_endpoint": "/weather",
+                "forecast_endpoint": "/forecast",
+                "timeout": 10,
+                "units": "metric",
+                "forecast_count": 24
+            },
+            "uv": {"peak_value": 8.0},
+            "display": {
+                "datetime_format": "%Y-%m-%d %H:%M:%S %Z",
+                "temperature_unit": "°C",
+                "wind_unit": "m/s"
+            },
+            "input": {"allowed_extra_chars": "-'. "}
+        }
+
+    return _config_cache

--- a/src/get_current_weather.py
+++ b/src/get_current_weather.py
@@ -1,21 +1,37 @@
-import requests
+"""Fetch current weather data from OpenWeatherMap API."""
+
 from datetime import datetime
+import requests
 import pytz
-import math
-from pysolar.solar import get_altitude
 
-UV_PEAK = 8.0  # Estimated daily peak UV value
+from src.uv_calculator import estimate_uv_index
+from src.config_loader import load_config
 
-def get_weather_with_uv(openweathermap_api_key: str, city: str):
-    if not openweathermap_api_key or not openweathermap_api_key.strip():
-        print("Error: Invalid API key provided")
+
+def get_weather_with_uv(api_key: str, city: str) -> dict | None:
+    """Fetch current weather for a city, including estimated UV index.
+
+    Args:
+        api_key: OpenWeatherMap API key.
+        city: City name to query.
+
+    Returns:
+        Dictionary with weather data, or None on failure.
+    """
+    if not api_key or not api_key.strip():
+        print("Error: Invalid API key provided.")
         return None
 
-    url = "http://api.openweathermap.org/data/2.5/weather"
-    params = {"q": city, "appid": openweathermap_api_key, "units": "metric"}
+    config = load_config()
+    api = config['api']
+    display = config['display']
+    uv_peak = config['uv']['peak_value']
+
+    url = f"{api['base_url']}{api['current_endpoint']}"
+    params = {"q": city, "appid": api_key, "units": api['units']}
 
     try:
-        resp = requests.get(url, params=params)
+        resp = requests.get(url, params=params, timeout=api['timeout'])
         data = resp.json()
 
         if resp.status_code != 200:
@@ -25,17 +41,16 @@ def get_weather_with_uv(openweathermap_api_key: str, city: str):
         lat = data["coord"]["lat"]
         lon = data["coord"]["lon"]
 
+        # Build local timezone from API offset
         tz_offset = data.get("timezone", 0)
-        local_tz = pytz.FixedOffset(tz_offset // 60)        # Calculate UV index using solar position at current local time
-        current_time_local = datetime.now(tz=local_tz)
-        current_time_utc = current_time_local.astimezone(pytz.utc)
-        altitude_deg = get_altitude(lat, lon, current_time_utc)
+        local_tz = pytz.FixedOffset(tz_offset // 60)
 
-        if altitude_deg > 0:
-            uv_value = round(UV_PEAK * math.sin(math.radians(altitude_deg)), 2)
-        else:
-            uv_value = 0.0
+        # Estimate UV index from solar position
+        current_time_utc = datetime.now(tz=pytz.utc)
+        uv_value = estimate_uv_index(lat, lon, current_time_utc, uv_peak)
 
+        # Format sunrise/sunset in local time
+        dt_format = display['datetime_format']
         sunrise = datetime.fromtimestamp(data["sys"]["sunrise"], tz=local_tz)
         sunset = datetime.fromtimestamp(data["sys"]["sunset"], tz=local_tz)
 
@@ -49,8 +64,8 @@ def get_weather_with_uv(openweathermap_api_key: str, city: str):
             "humidity": data["main"]["humidity"],
             "wind_speed": data["wind"]["speed"],
             "wind_direction": data["wind"]["deg"],
-            "sunrise": sunrise.strftime("%Y-%m-%d %H:%M:%S %Z"),
-            "sunset": sunset.strftime("%Y-%m-%d %H:%M:%S %Z"),
+            "sunrise": sunrise.strftime(dt_format),
+            "sunset": sunset.strftime(dt_format),
             "icon": data["weather"][0]["icon"],
             "uv_index": uv_value,
             "cloudiness": data["clouds"]["all"],
@@ -59,6 +74,16 @@ def get_weather_with_uv(openweathermap_api_key: str, city: str):
             "rain": data.get("rain", {}).get("1h", "0 mm"),
             "snow": data.get("snow", {}).get("1h", "0 mm"),
         }
-    except Exception as e:
-        print(f"Error fetching current weather: {e}")
+
+    except requests.exceptions.Timeout:
+        print("Error: Request timed out. Try again later.")
+        return None
+    except requests.exceptions.ConnectionError:
+        print("Error: Could not connect to the weather service.")
+        return None
+    except requests.exceptions.RequestException as e:
+        print(f"Error: Network request failed: {e}")
+        return None
+    except (KeyError, TypeError) as e:
+        print(f"Error: Unexpected response format: {e}")
         return None

--- a/src/get_weather_forecast.py
+++ b/src/get_weather_forecast.py
@@ -1,53 +1,87 @@
+"""Fetch weather forecast data from OpenWeatherMap API."""
+
 from datetime import datetime
 import requests
-import math
 import pytz
-from pysolar.solar import get_altitude
 
-UV_PEAK = 8.0  # Estimated daily peak UV value
+from src.uv_calculator import estimate_uv_index
+from src.config_loader import load_config
 
-def get_forecast(openweathermap_api_key: str, city: str):
-    if not openweathermap_api_key or not openweathermap_api_key.strip():
-        print("Error: Invalid API key provided")
+
+def get_forecast(api_key: str, city: str) -> list[dict] | None:
+    """Fetch 3-day forecast for a city, including estimated UV index.
+
+    Args:
+        api_key: OpenWeatherMap API key.
+        city: City name to query.
+
+    Returns:
+        List of forecast dictionaries, or None on failure.
+    """
+    if not api_key or not api_key.strip():
+        print("Error: Invalid API key provided.")
         return None
 
-    url = "http://api.openweathermap.org/data/2.5/forecast"
-    params = {"q": city, "appid": openweathermap_api_key, "units": "metric", "cnt": 24}
-    resp = requests.get(url, params=params)
-    data = resp.json()
-    if resp.status_code != 200:
-        print(f"API error (forecast): {data.get('message','Unknown error')}")
+    config = load_config()
+    api = config['api']
+    display = config['display']
+    uv_peak = config['uv']['peak_value']
+
+    url = f"{api['base_url']}{api['forecast_endpoint']}"
+    params = {
+        "q": city,
+        "appid": api_key,
+        "units": api['units'],
+        "cnt": api['forecast_count']
+    }
+
+    try:
+        resp = requests.get(url, params=params, timeout=api['timeout'])
+        data = resp.json()
+
+        if resp.status_code != 200:
+            print(f"API error (forecast): {data.get('message', 'Unknown error')}")
+            return None
+
+        coord = data["city"]["coord"]
+        lat, lon = coord["lat"], coord["lon"]
+        tz_offset = data["city"].get("timezone", 0)
+        local_tz = pytz.FixedOffset(tz_offset // 60)
+        dt_format = display['datetime_format']
+
+        forecasts = []
+        for item in data["list"]:
+            ts = item["dt"]
+
+            # Calculate UV from solar position at forecast time
+            dt_utc = datetime.fromtimestamp(ts, tz=pytz.utc)
+            uv_val = estimate_uv_index(lat, lon, dt_utc, uv_peak)
+
+            # Convert to local timezone for display
+            dt_local = datetime.fromtimestamp(ts, tz=local_tz)
+            dt_str = dt_local.strftime(dt_format)
+
+            forecasts.append({
+                "datetime": dt_str,
+                "temperature": item["main"]["temp"],
+                "description": item["weather"][0]["description"],
+                "humidity": item["main"]["humidity"],
+                "wind_speed": item["wind"]["speed"],
+                "icon": item["weather"][0]["icon"],
+                "uv_index": uv_val
+            })
+
+        return forecasts
+
+    except requests.exceptions.Timeout:
+        print("Error: Request timed out. Try again later.")
         return None
-
-    coord = data["city"]["coord"]
-    lat, lon = coord["lat"], coord["lon"]
-    tz_offset = data["city"].get("timezone", 0)
-    local_tz = pytz.FixedOffset(tz_offset // 60)
-
-    forecasts = []
-    for item in data["list"]:
-        ts = item["dt"]
-
-        # UTC timestamp for UV calculation
-        dt_utc = datetime.fromtimestamp(ts, tz=pytz.utc)
-        altitude_deg = get_altitude(lat, lon, dt_utc)
-        if altitude_deg > 0:
-            uv_val = round(UV_PEAK * math.sin(math.radians(altitude_deg)), 2)
-        else:
-            uv_val = 0.0
-
-        # Convert to local timezone
-        dt_local = datetime.fromtimestamp(ts, tz=local_tz)
-        dt_str = dt_local.strftime("%Y-%m-%d %H:%M:%S %Z")
-
-        forecasts.append({
-            "datetime": dt_str,
-            "temperature": item["main"]["temp"],
-            "description": item["weather"][0]["description"],
-            "humidity": item["main"]["humidity"],
-            "wind_speed": item["wind"]["speed"],
-            "icon": item["weather"][0]["icon"],
-            "uv_index": uv_val
-        })
-
-    return forecasts
+    except requests.exceptions.ConnectionError:
+        print("Error: Could not connect to the weather service.")
+        return None
+    except requests.exceptions.RequestException as e:
+        print(f"Error: Network request failed: {e}")
+        return None
+    except (KeyError, TypeError) as e:
+        print(f"Error: Unexpected response format: {e}")
+        return None

--- a/src/main_program.py
+++ b/src/main_program.py
@@ -1,32 +1,49 @@
+"""Main program loop for the weather application."""
+
 from dotenv import load_dotenv, find_dotenv
 import os
 
 from src.get_current_weather import get_weather_with_uv
 from src.get_weather_forecast import get_forecast
+from src.config_loader import load_config
+
+
+def _validate_city_name(city: str, extra_chars: str) -> bool:
+    """Check if city name contains only allowed characters.
+
+    Letters (including Finnish å, ä, ö) are always allowed.
+    Additional characters (hyphens, apostrophes, etc.) come from config.
+    """
+    allowed = set("abcdefghijklmnopqrstuvwxyzåäöABCDEFGHIJKLMNOPQRSTUVWXYZÅÄÖ" + extra_chars)
+    return bool(city) and set(city).issubset(allowed)
+
 
 def run():
+    """Entry point for the weather application."""
     print()
     print('Welcome to the weather app!')
     print('---------------------------')
     print()
 
     load_dotenv(find_dotenv())
-    openweathermap_api_key = os.getenv('OPENWEATHERMAP_API_KEY')
+    api_key = os.getenv('OPENWEATHERMAP_API_KEY')
 
-    # Check if API key is set
-    if not openweathermap_api_key:
+    # Validate API key
+    if not api_key:
         print("Error: OpenWeatherMap API key not found!")
         print("Please set your API key in the .env file as:")
         print("OPENWEATHERMAP_API_KEY=your_api_key_here")
         print("\nYou can get a free API key from: https://openweathermap.org/api")
         return
 
-    if not openweathermap_api_key.strip():
+    if not api_key.strip():
         print("Error: OpenWeatherMap API key is empty!")
         print("Please check your .env file and make sure the API key is properly set.")
         return
 
-    allowed_characters = set("abcdefghijklmnopqrstuvwxyzåäöABCDEFGHIJKLMNOPQRSTUVWXYZÅÄÖ ")
+    config = load_config()
+    display = config['display']
+    extra_chars = config['input']['allowed_extra_chars']
 
     running = True
     city = None
@@ -34,32 +51,33 @@ def run():
     while running:
         output = ""
 
+        # Get city name if not reusing
         if not city:
             while True:
                 city = input('Enter a city (or type "exit" to quit): ').strip().lower()
                 if city == "exit":
                     print('Thanks for using the app. Goodbye!')
                     return
-                if set(city).issubset(allowed_characters):
+                if _validate_city_name(city, extra_chars):
                     break
                 print('Please enter a valid city name.\n')
 
+        # Choose current weather or forecast
         while True:
-            choice = input('Do you want the current weather or the 3-day forecast? (1 = current, 2 = forecast): ')
+            choice = input('Current weather or 3-day forecast? (1 = current, 2 = forecast): ')
             if choice in ('1', '2'):
-                current_or_forecast = int(choice)
                 break
             print('Please enter 1 or 2.')
 
-        if current_or_forecast == 1:
-            weather = get_weather_with_uv(openweathermap_api_key, city) # type: ignore
+        if choice == '1':
+            weather = get_weather_with_uv(api_key, city)
             if weather:
                 print()
                 print(f'Current weather in {city.capitalize()}:')
                 for key, value in weather.items():
                     output += f'{key.capitalize()}: {value}\n'
             else:
-                print(f"Sorry, the weather data for {city.capitalize()} could not be retrieved.")
+                print(f"Sorry, weather data for {city.capitalize()} could not be retrieved.")
                 if input('Try another city? (1 = yes, 2 = no): ') == '2':
                     print('Goodbye!')
                     return
@@ -67,20 +85,22 @@ def run():
                 continue
 
         else:
-            forecasts = get_forecast(openweathermap_api_key, city) # type: ignore
+            forecasts = get_forecast(api_key, city)
             if forecasts:
+                temp_unit = display['temperature_unit']
+                wind_unit = display['wind_unit']
                 print()
                 print(f'3-day forecast for {city.capitalize()}:\n')
                 for f in forecasts:
                     output += f"Date and Time: {f['datetime']}\n"
-                    output += f"Temperature: {f['temperature']}°C\n"
+                    output += f"Temperature: {f['temperature']}{temp_unit}\n"
                     output += f"Description: {f['description']}\n"
                     output += f"Humidity: {f['humidity']}%\n"
-                    output += f"Wind Speed: {f['wind_speed']} m/s\n"
+                    output += f"Wind Speed: {f['wind_speed']} {wind_unit}\n"
                     output += f"UV Index: {f['uv_index']}\n"
                     output += '-----------------------------------\n'
             else:
-                print(f"Sorry, the forecast for {city.capitalize()} could not be retrieved.")
+                print(f"Sorry, forecast for {city.capitalize()} could not be retrieved.")
                 if input('Try another city? (1 = yes, 2 = no): ') == '2':
                     print('Goodbye!')
                     return
@@ -89,6 +109,7 @@ def run():
 
         print(output)
 
+        # Next action
         while True:
             again = input('What next? (1 = new city, 2 = reuse same city, 3 = quit): ')
             if again == '3':

--- a/src/uv_calculator.py
+++ b/src/uv_calculator.py
@@ -1,0 +1,30 @@
+"""Shared UV index estimation based on solar altitude angle."""
+
+import math
+from datetime import datetime
+import pytz
+from pysolar.solar import get_altitude
+
+
+def estimate_uv_index(lat: float, lon: float, dt_utc: datetime, uv_peak: float) -> float:
+    """Estimate UV index from solar position.
+
+    Uses the sun's altitude angle to scale a peak UV value.
+    This is an approximation — real UV depends on cloud cover,
+    ozone layer thickness, and surface reflection.
+
+    Args:
+        lat: Latitude of the location.
+        lon: Longitude of the location.
+        dt_utc: UTC datetime for the calculation.
+        uv_peak: Estimated maximum UV index for the location.
+
+    Returns:
+        Estimated UV index (0.0 if sun is below horizon).
+    """
+    altitude_deg = get_altitude(lat, lon, dt_utc)
+
+    if altitude_deg > 0:
+        return round(uv_peak * math.sin(math.radians(altitude_deg)), 2)
+
+    return 0.0


### PR DESCRIPTION
## Config-driven weather app with shared UV calculator and dependency updates

### Problem

UV index calculation was duplicated across `get_current_weather.py` and `get_weather_forecast.py`. API URLs, timeouts, display formats, and input validation rules were hardcoded. The forecast module had no error handling — a single `KeyError` or network timeout would crash the app. API calls used `http://` instead of `https://`. Dependencies were outdated, including a security vulnerability in `requests`.

### Security

- **requests 2.32.3 → 2.32.5** — Fixes CVE-2024-47081 (medium). Versions prior to 2.32.4 could leak `.netrc` credentials to third parties via maliciously crafted URLs.

### Dependency updates

- **python-dotenv 1.0.1 → 1.2.2** — Symlink handling fixes, Python 3.14 support.
- **pytz 2024.1 → 2026.1.post1** — Updated IANA timezone database.
- **pysolar 0.13** — Already latest, no change.

### New files

- `config/weather_config.json` — API endpoints, request timeout, UV peak value, display formats, allowed input characters.
- `src/config_loader.py` — Loads config with caching and built-in fallback defaults.
- `src/uv_calculator.py` — Single `estimate_uv_index()` function used by both weather modules.

### Updated files

- `get_current_weather.py` / `get_weather_forecast.py` — Use shared config and UV calculator. Switched to `https://`. Added timeout to all requests. Specific error handling for timeout, connection failure, and unexpected response format.
- `main_program.py` — City input validation uses configurable character set (now supports hyphens, apostrophes). Display units come from config.
- `requirements.txt` — Updated all dependencies.
- `README.md` — Rewritten for new architecture.

### How to test
```bash
pip install -r requirements.txt
python3 main.py
# city: helsinki / choice: 1 (current) -> verify weather data with UV
# city: helsinki / choice: 2 (forecast) -> verify 3-day forecast with UV
# city: stratford-upon-avon -> verify hyphenated city names work
# disconnect wifi, try again -> verify timeout/connection error messages
```

### Breaking changes

None. The `.env` file and API key setup remain the same.