### PR TITLE
Chore/polish weather cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,101 +1,114 @@
 # Weather View
 
-## Overview
-
-A Python application that fetches real-time weather data and 3-day forecasts for any city using the [OpenWeatherMap API](https://openweathermap.org/api). Includes estimated UV index calculations based on solar position via the pysolar library.
+A small Python command-line app for checking current weather and 3-day forecasts with the [OpenWeatherMap API](https://openweathermap.org/api). It also estimates UV index values from solar altitude using `pysolar`.
 
 ## Features
 
-- Current weather: temperature, humidity, wind, pressure, sunrise/sunset, cloudiness, rain/snow
-- 3-day forecast in 3-hour intervals with UV index estimation
-- Config-driven settings — API parameters, UV peak value, display formats, and input rules live in a JSON file
-- Shared UV calculator module to avoid code duplication
-- Proper error handling with specific messages for timeouts, connection failures, and unexpected responses
-- Input validation for city names (configurable allowed characters)
-- Timezone-aware timestamps using the city's local time
+- Current weather: temperature, humidity, wind, pressure, sunrise/sunset, cloudiness, rain, and snow
+- 3-day forecast in 3-hour intervals with estimated UV index values
+- Config-driven API settings, display formats, UV peak value, and city input rules
+- Timezone-aware timestamps based on the queried city's local offset
+- Clear handling for missing API keys, API errors, timeouts, connection failures, and malformed responses
+- Focused unit tests for validation, configuration loading, UV estimation, and API client behavior
 
 ## Project Structure
 
-\```
+```text
 weather_view/
-├── main.py                          # Entry point
+├── main.py
 ├── requirements.txt
-├── .env                             # API key (not committed)
 ├── config/
-│   └── weather_config.json          # API URLs, UV settings, display formats
-└── src/
-    ├── __init__.py
-    ├── main_program.py              # CLI input loop
-    ├── get_current_weather.py       # Current weather fetcher
-    ├── get_weather_forecast.py      # Forecast fetcher
-    ├── uv_calculator.py             # Shared UV index estimation
-    └── config_loader.py             # Config file loader with caching
-\```
+│   └── weather_config.json
+├── src/
+│   ├── config_loader.py
+│   ├── get_current_weather.py
+│   ├── get_weather_forecast.py
+│   ├── main_program.py
+│   └── uv_calculator.py
+└── tests/
+    ├── test_config_loader.py
+    ├── test_main_program.py
+    ├── test_uv_calculator.py
+    └── test_weather_clients.py
+```
 
-## Prerequisites
+## Requirements
 
 - Python 3.10+
-- pip
+- An OpenWeatherMap API key
 
-## Installation
+## Setup
 
-1. Clone the repository:
-\```bash
-git clone <repository-url>
-cd weather_view
-\```
+1. Create and activate a virtual environment:
 
-2. Create a virtual environment and activate it:
-\```bash
+```bash
 python3 -m venv venv
 source venv/bin/activate
-\```
+```
 
-3. Install dependencies:
-\```bash
-pip install -r requirements.txt
-\```
+2. Install dependencies:
 
-4. Create a `.env` file in the project root with your API key:
-\```
+```bash
+python -m pip install -r requirements.txt
+```
+
+3. Create a `.env` file in the project root:
+
+```text
 OPENWEATHERMAP_API_KEY=your_api_key_here
-\```
+```
 
-You can get a free API key from [OpenWeatherMap](https://openweathermap.org/api).
-
-## Configuration
-
-### API Key (`.env`)
-
-The API key is loaded from a `.env` file via python-dotenv. The app validates the key on startup and provides clear instructions if it's missing or empty.
-
-### App Settings (`config/weather_config.json`)
-
-Controls API endpoints, request timeout, units, UV estimation peak value, display formats, and allowed characters in city name input. All settings have sensible defaults built into the code as a fallback.
+You can create a free API key from [OpenWeatherMap](https://openweathermap.org/api). The `.env` file is ignored by Git and should not be committed.
 
 ## Usage
 
-\```bash
+```bash
 python3 main.py
-\```
+```
 
-You will be prompted for:
+The app will ask for:
 
-1. **City name** — e.g. `helsinki`, `london`, `new york`. Type `exit` to quit.
-2. **Data type** — `1` for current weather, `2` for 3-day forecast.
-3. **Next action** — `1` for new city, `2` to reuse same city, `3` to quit.
+1. City name, for example `helsinki`, `london`, or `new york`. Type `exit` to quit.
+2. Data type: `1` for current weather or `2` for 3-day forecast.
+3. Next action: `1` for a new city, `2` to reuse the same city, or `3` to quit.
+
+## Configuration
+
+Runtime settings live in `config/weather_config.json`:
+
+- OpenWeatherMap endpoints, timeout, units, and forecast count
+- Display units and datetime format
+- Estimated peak UV value
+- Extra characters allowed in city names
+
+If the config file is missing or invalid, the app falls back to built-in defaults and prints a warning.
+
+## Testing
+
+Run the unit tests with:
+
+```bash
+python -m unittest discover -s tests
+```
+
+You can also run a quick syntax check:
+
+```bash
+python -m compileall -q main.py src tests
+```
 
 ## UV Index Note
 
-The UV index is estimated using solar altitude angle calculations (via pysolar), not from a dedicated UV API. The estimation uses a configurable peak UV value (default: 8.0) scaled by `sin(solar_altitude)`. This is an approximation — actual UV depends on cloud cover, ozone, and surface conditions. The UV index will show 0.0 during nighttime hours.
+The UV index is estimated from solar altitude, not fetched from a dedicated UV API. It uses a configurable peak UV value scaled by `sin(solar_altitude)`, so actual UV conditions may differ because of clouds, ozone, altitude, and surface reflection. Nighttime values return `0.0`.
 
 ## Troubleshooting
 
-- **"API key not found"** — make sure `.env` exists in the project root with the correct format.
-- **"API error"** — verify your API key is valid and active at openweathermap.org.
-- **"Request timed out"** — the weather service may be temporarily unavailable. The timeout is configurable in `weather_config.json`.
-- **UV index is always 0** — normal during nighttime in the queried city.
-- **City not found** — try the full city name or check spelling.
+- **"API key not found"**: make sure `.env` exists in the project root and contains `OPENWEATHERMAP_API_KEY`.
+- **"API error"**: verify that your OpenWeatherMap API key is valid and active.
+- **"Request timed out"**: the weather service may be temporarily unavailable, or the timeout may need adjustment in `weather_config.json`.
+- **"Unexpected response format"**: the API returned data in a format the app could not parse.
+- **UV index is always 0**: this is expected during nighttime in the queried city.
+- **City not found**: try the full city name or check the spelling.
 
 ## License
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 python-dotenv==1.2.2   # Load API key from .env file
-requests==2.32.5       # HTTP requests (CVE-2024-47081 fix)
-pytz==2026.1.post1     # Timezone handling
+requests==2.34.2       # HTTP requests
+pytz==2026.2            # Timezone handling
 pysolar==0.13          # Solar position for UV index estimation

--- a/src/get_current_weather.py
+++ b/src/get_current_weather.py
@@ -32,7 +32,15 @@ def get_weather_with_uv(api_key: str, city: str) -> dict | None:
 
     try:
         resp = requests.get(url, params=params, timeout=api['timeout'])
-        data = resp.json()
+        try:
+            data = resp.json()
+        except ValueError as e:
+            print(f"Error: Unexpected response format: invalid JSON ({e})")
+            return None
+
+        if not isinstance(data, dict):
+            print("Error: Unexpected response format: expected a JSON object.")
+            return None
 
         if resp.status_code != 200:
             print(f"API error: {data.get('message', 'Unknown error')}")
@@ -84,6 +92,6 @@ def get_weather_with_uv(api_key: str, city: str) -> dict | None:
     except requests.exceptions.RequestException as e:
         print(f"Error: Network request failed: {e}")
         return None
-    except (KeyError, TypeError) as e:
+    except (KeyError, TypeError, IndexError, AttributeError) as e:
         print(f"Error: Unexpected response format: {e}")
         return None

--- a/src/get_weather_forecast.py
+++ b/src/get_weather_forecast.py
@@ -37,7 +37,15 @@ def get_forecast(api_key: str, city: str) -> list[dict] | None:
 
     try:
         resp = requests.get(url, params=params, timeout=api['timeout'])
-        data = resp.json()
+        try:
+            data = resp.json()
+        except ValueError as e:
+            print(f"Error: Unexpected response format: invalid JSON ({e})")
+            return None
+
+        if not isinstance(data, dict):
+            print("Error: Unexpected response format: expected a JSON object.")
+            return None
 
         if resp.status_code != 200:
             print(f"API error (forecast): {data.get('message', 'Unknown error')}")
@@ -82,6 +90,6 @@ def get_forecast(api_key: str, city: str) -> list[dict] | None:
     except requests.exceptions.RequestException as e:
         print(f"Error: Network request failed: {e}")
         return None
-    except (KeyError, TypeError) as e:
+    except (KeyError, TypeError, IndexError, AttributeError) as e:
         print(f"Error: Unexpected response format: {e}")
         return None

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -1,0 +1,64 @@
+"""Tests for configuration loading."""
+
+import json
+from pathlib import Path
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from src import config_loader
+
+
+class LoadConfigTest(unittest.TestCase):
+    def tearDown(self):
+        config_loader._config_cache = None
+
+    def test_uses_defaults_when_config_file_is_missing(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            config_loader._config_cache = None
+
+            with patch.object(config_loader, "_project_root", temp_dir):
+                with patch("builtins.print"):
+                    config = config_loader.load_config()
+
+        self.assertEqual(config["api"]["base_url"], "https://api.openweathermap.org/data/2.5")
+        self.assertEqual(config["api"]["forecast_count"], 24)
+        self.assertEqual(config["uv"]["peak_value"], 8.0)
+
+    def test_caches_loaded_config(self):
+        custom_config = {
+            "api": {
+                "base_url": "https://example.test",
+                "current_endpoint": "/weather",
+                "forecast_endpoint": "/forecast",
+                "timeout": 5,
+                "units": "metric",
+                "forecast_count": 8,
+            },
+            "uv": {"peak_value": 6.0},
+            "display": {
+                "datetime_format": "%Y-%m-%d",
+                "temperature_unit": "C",
+                "wind_unit": "m/s",
+            },
+            "input": {"allowed_extra_chars": "-"},
+        }
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            config_dir = Path(temp_dir) / "config"
+            config_dir.mkdir()
+            config_path = config_dir / "weather_config.json"
+            config_path.write_text(json.dumps(custom_config), encoding="utf-8")
+            config_loader._config_cache = None
+
+            with patch.object(config_loader, "_project_root", temp_dir):
+                first = config_loader.load_config()
+                config_path.write_text("{invalid json", encoding="utf-8")
+                second = config_loader.load_config()
+
+        self.assertIs(first, second)
+        self.assertEqual(second["api"]["base_url"], "https://example.test")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_main_program.py
+++ b/tests/test_main_program.py
@@ -1,0 +1,25 @@
+"""Tests for CLI input helpers."""
+
+import unittest
+
+from src.main_program import _validate_city_name
+
+
+class ValidateCityNameTest(unittest.TestCase):
+    def test_accepts_letters_spaces_and_configured_extra_characters(self):
+        extra_chars = "-'. "
+
+        self.assertTrue(_validate_city_name("new york", extra_chars))
+        self.assertTrue(_validate_city_name("saint-jean", extra_chars))
+        self.assertTrue(_validate_city_name("o'fallon", extra_chars))
+
+    def test_rejects_empty_or_unconfigured_characters(self):
+        extra_chars = "-'. "
+
+        self.assertFalse(_validate_city_name("", extra_chars))
+        self.assertFalse(_validate_city_name("paris!", extra_chars))
+        self.assertFalse(_validate_city_name("tokyo2", extra_chars))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_uv_calculator.py
+++ b/tests/test_uv_calculator.py
@@ -1,0 +1,31 @@
+"""Tests for UV index estimation."""
+
+from datetime import datetime
+import unittest
+from unittest.mock import patch
+
+import pytz
+
+from src.uv_calculator import estimate_uv_index
+
+
+class EstimateUvIndexTest(unittest.TestCase):
+    def test_scales_peak_value_by_solar_altitude(self):
+        dt_utc = datetime(2026, 6, 17, 12, 0, tzinfo=pytz.utc)
+
+        with patch("src.uv_calculator.get_altitude", return_value=30):
+            result = estimate_uv_index(60.17, 24.94, dt_utc, 8.0)
+
+        self.assertEqual(result, 4.0)
+
+    def test_returns_zero_when_sun_is_below_horizon(self):
+        dt_utc = datetime(2026, 6, 17, 0, 0, tzinfo=pytz.utc)
+
+        with patch("src.uv_calculator.get_altitude", return_value=-5):
+            result = estimate_uv_index(60.17, 24.94, dt_utc, 8.0)
+
+        self.assertEqual(result, 0.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_weather_clients.py
+++ b/tests/test_weather_clients.py
@@ -1,0 +1,142 @@
+"""Tests for OpenWeatherMap API client modules."""
+
+import unittest
+from unittest.mock import patch
+
+from src.get_current_weather import get_weather_with_uv
+from src.get_weather_forecast import get_forecast
+
+
+TEST_CONFIG = {
+    "api": {
+        "base_url": "https://api.example.test",
+        "current_endpoint": "/weather",
+        "forecast_endpoint": "/forecast",
+        "timeout": 3,
+        "units": "metric",
+        "forecast_count": 2,
+    },
+    "uv": {"peak_value": 8.0},
+    "display": {
+        "datetime_format": "%Y-%m-%d %H:%M:%S %Z",
+        "temperature_unit": "C",
+        "wind_unit": "m/s",
+    },
+    "input": {"allowed_extra_chars": "-'. "},
+}
+
+
+class MockResponse:
+    def __init__(self, status_code, payload=None, json_error=None):
+        self.status_code = status_code
+        self.payload = payload
+        self.json_error = json_error
+
+    def json(self):
+        if self.json_error:
+            raise self.json_error
+
+        return self.payload
+
+
+class CurrentWeatherClientTest(unittest.TestCase):
+    def test_returns_current_weather_with_estimated_uv(self):
+        payload = {
+            "coord": {"lat": 60.17, "lon": 24.94},
+            "timezone": 7200,
+            "sys": {"sunrise": 1781671200, "sunset": 1781730000},
+            "name": "Helsinki",
+            "main": {
+                "temp": 18.5,
+                "feels_like": 17.9,
+                "temp_max": 19.0,
+                "temp_min": 17.0,
+                "humidity": 64,
+                "pressure": 1014,
+            },
+            "weather": [{"description": "clear sky", "icon": "01d"}],
+            "wind": {"speed": 4.2, "deg": 220},
+            "clouds": {"all": 12},
+            "visibility": 10000,
+        }
+        response = MockResponse(200, payload)
+
+        with patch("src.get_current_weather.load_config", return_value=TEST_CONFIG):
+            with patch("src.get_current_weather.estimate_uv_index", return_value=4.2):
+                with patch("src.get_current_weather.requests.get", return_value=response) as get:
+                    result = get_weather_with_uv("api-key", "helsinki")
+
+        self.assertEqual(result["city"], "Helsinki")
+        self.assertEqual(result["uv_index"], 4.2)
+        self.assertEqual(result["rain"], "0 mm")
+        get.assert_called_once_with(
+            "https://api.example.test/weather",
+            params={"q": "helsinki", "appid": "api-key", "units": "metric"},
+            timeout=3,
+        )
+
+    def test_returns_none_for_invalid_json(self):
+        response = MockResponse(200, json_error=ValueError("bad json"))
+
+        with patch("src.get_current_weather.load_config", return_value=TEST_CONFIG):
+            with patch("src.get_current_weather.requests.get", return_value=response):
+                with patch("builtins.print") as print_mock:
+                    result = get_weather_with_uv("api-key", "helsinki")
+
+        self.assertIsNone(result)
+        print_mock.assert_called_once()
+        self.assertIn("invalid JSON", print_mock.call_args.args[0])
+
+
+class ForecastClientTest(unittest.TestCase):
+    def test_returns_forecast_with_estimated_uv(self):
+        payload = {
+            "city": {
+                "coord": {"lat": 60.17, "lon": 24.94},
+                "timezone": 7200,
+            },
+            "list": [
+                {
+                    "dt": 1781690400,
+                    "main": {"temp": 19.0, "humidity": 58},
+                    "weather": [{"description": "few clouds", "icon": "02d"}],
+                    "wind": {"speed": 3.6},
+                }
+            ],
+        }
+        response = MockResponse(200, payload)
+
+        with patch("src.get_weather_forecast.load_config", return_value=TEST_CONFIG):
+            with patch("src.get_weather_forecast.estimate_uv_index", return_value=5.1):
+                with patch("src.get_weather_forecast.requests.get", return_value=response) as get:
+                    result = get_forecast("api-key", "helsinki")
+
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["temperature"], 19.0)
+        self.assertEqual(result[0]["uv_index"], 5.1)
+        get.assert_called_once_with(
+            "https://api.example.test/forecast",
+            params={
+                "q": "helsinki",
+                "appid": "api-key",
+                "units": "metric",
+                "cnt": 2,
+            },
+            timeout=3,
+        )
+
+    def test_returns_none_for_invalid_json(self):
+        response = MockResponse(200, json_error=ValueError("bad json"))
+
+        with patch("src.get_weather_forecast.load_config", return_value=TEST_CONFIG):
+            with patch("src.get_weather_forecast.requests.get", return_value=response):
+                with patch("builtins.print") as print_mock:
+                    result = get_forecast("api-key", "helsinki")
+
+        self.assertIsNone(result)
+        print_mock.assert_called_once()
+        self.assertIn("invalid JSON", print_mock.call_args.args[0])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Summary

Polish the Weather View CLI for portfolio readiness with safer API response handling, refreshed dependency pins, focused unit tests, and a cleaner README.

### What changed

- Added malformed JSON and unexpected response-shape handling for current weather and forecast API calls.
- Added stdlib `unittest` coverage for city validation, config fallback/caching, UV estimation, and mocked OpenWeatherMap client flows.
- Updated direct dependency pins:
  - `requests` to `2.34.2`
  - `pytz` to `2026.2`
- Reworked the README with valid Markdown fences, clearer setup/usage/testing instructions, project structure, and troubleshooting notes.

### Notes

- No CLI prompt flow or public entrypoint changes.
- No version bump was made because this repository has no `package.json` or other version field.